### PR TITLE
Fix: Ensure pixelCanvas dimensions are integers

### DIFF
--- a/game.js
+++ b/game.js
@@ -22,8 +22,9 @@ const ROUND_DURATION_SECONDS = 90;
 const BALL_RADIUS = 15;
 
 const PIXEL_SCALE = 6;
-const PIXEL_CANVAS_WIDTH = CANVAS_WIDTH / PIXEL_SCALE;
-const PIXEL_CANVAS_HEIGHT = CANVAS_HEIGHT / PIXEL_SCALE;
+// Ensure integer dimensions for the pixelCanvas by flooring the result
+const PIXEL_CANVAS_WIDTH = Math.floor(CANVAS_WIDTH / PIXEL_SCALE);
+const PIXEL_CANVAS_HEIGHT = Math.floor(CANVAS_HEIGHT / PIXEL_SCALE);
 
 // --- Collision Categories ---
 const playerCategory = 0x0001;


### PR DESCRIPTION
- Modified the calculation of PIXEL_CANVAS_WIDTH and PIXEL_CANVAS_HEIGHT to use Math.floor() when dividing CANVAS_WIDTH/HEIGHT by PIXEL_SCALE.
- This ensures that the offscreen pixelCanvas is created with integer dimensions, preventing potential rendering issues or inconsistencies across different browsers that might arise from fractional canvas dimensions.