### PR TITLE
Fix: Set canvas dimensions to resolve element invisibility

### DIFF
--- a/game.js
+++ b/game.js
@@ -73,6 +73,10 @@ const keysPressed = {};
  * تابع اصلی برای راه‌اندازی کل بازی
  */
 function setup() {
+    // Set canvas dimensions correctly
+    canvas.width = CANVAS_WIDTH;
+    canvas.height = CANVAS_HEIGHT;
+
     // 1. ساخت موتور فیزیک
     engine = Engine.create();
     world = engine.world;


### PR DESCRIPTION
Previously, the HTML canvas element's width and height attributes were not explicitly set, causing it to default to 300x150 pixels. Game logic and rendering operated on an 800x600 coordinate system, resulting in most game elements being drawn outside the canvas's actual drawing buffer.

This commit fixes the issue by adding the following lines at the beginning of the `setup()` function in `game.js`:
```javascript
canvas.width = CANVAS_WIDTH;
canvas.height = CANVAS_HEIGHT;
```
This ensures the canvas drawing surface dimensions match the game's intended 800x600 resolution, making all game elements (players, ball, field) visible.