### PR TITLE
Docs: Add critical comments about canvas dimensioning

### DIFF
--- a/game.js
+++ b/game.js
@@ -73,7 +73,11 @@ const keysPressed = {};
  * تابع اصلی برای راه‌اندازی کل بازی
  */
 function setup() {
-    // Set canvas dimensions correctly
+    // CRITICAL STEP: Set the canvas element's actual drawing surface dimensions.
+    // Without these lines, the canvas defaults to 300x150 pixels,
+    // and most game elements (designed for 800x600) will be drawn
+    // outside these bounds, making them invisible.
+    // This is ESSENTIAL for the game to render correctly.
     canvas.width = CANVAS_WIDTH;
     canvas.height = CANVAS_HEIGHT;
 


### PR DESCRIPTION
Added detailed comments in `game.js` above the `canvas.width` and `canvas.height` assignments within the `setup()` function.

These comments highlight that setting these attributes is crucial for establishing the correct drawing resolution of the canvas. Omitting these lines would lead to the canvas defaulting to a smaller size (e.g., 300x150), causing game elements designed for the larger `CANVAS_WIDTH` and `CANVAS_HEIGHT` (800x600) to be rendered off-screen or incorrectly, thus appearing invisible. This clarification aims to prevent future regressions and improve code maintainability.