### PR TITLE
Fix: Significantly increase chip shot forces

### DIFF
--- a/game.js
+++ b/game.js
@@ -88,8 +88,8 @@ const MOVE_FORCE = 0.015;
 const AIR_MOVE_FORCE_MULTIPLIER = 0.1; // Reduced from 0.3 to 0.1 (10%)
 
 // Chip Shot Constants
-const CHIP_SHOT_UP_FORCE = 0.13; // Adjusted from 0.15
-const CHIP_SHOT_FORWARD_FORCE = 0.025; // Increased from 0.010
+const CHIP_SHOT_UP_FORCE = 0.30; // Significantly increased from 0.13
+const CHIP_SHOT_FORWARD_FORCE = 0.05; // Significantly increased from 0.025
 
 const keysPressed = {};
 


### PR DESCRIPTION
- Increased CHIP_SHOT_UP_FORCE from 0.13 to 0.30.
- Increased CHIP_SHOT_FORWARD_FORCE from 0.025 to 0.05.

These changes are intended to make the chip shot effective and ensure the ball launches with noticeable height and forward motion, addressing the issue where the ball remained nearly stationary during previous chip attempts.