### PR TITLE
fix: Remove screen shake on goal

### DIFF
--- a/game.js
+++ b/game.js
@@ -402,7 +402,6 @@ function handleGoalScored(scoringTeam) {
     audioManager.playSound('goal');
 
     if (Math.random() < 0.20) {
-        triggerScreenShake(5, 15);
         let bounceXVelocity = (scoringTeam === 1) ? -(3 + Math.random() * 2) : (3 + Math.random() * 2);
         const bounceYVelocity = -(2 + Math.random() * 2);
         Body.setVelocity(ball, { x: bounceXVelocity, y: bounceYVelocity });


### PR DESCRIPTION
This commit removes the screen shake that occurs when a goal is scored. The screen now only shakes when the ball hits the post.